### PR TITLE
Provide "git-auto-commit-mode" feature

### DIFF
--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -115,4 +115,6 @@ mode turned on and optionally push them too."
       (add-hook 'after-save-hook 'gac-after-save-func t t)
     (remove-hook 'after-save-hook 'gac-after-save-func t)))
 
+(provide 'git-auto-commit-mode)
+
 ;;; git-auto-commit-mode.el ends here


### PR DESCRIPTION
Just a small fix to provide the feature.

I'm using John Wiegley's excellent `use-package` to initialize my Emacs. To be compatible with `use-package`, it is required that packages provide a feature.
