### PR TITLE
Quote filename for git add

### DIFF
--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -107,7 +107,7 @@ Default to FILENAME."
   (let* ((filename (buffer-file-name))
          (commit-msg (gac--commit-msg filename)))
     (shell-command
-     (concat "git add " filename " && git commit -m '" commit-msg "'"))))
+     (concat "git add '" filename "' && git commit -m '" commit-msg "'"))))
 
 (defun gac-push ()
   "Push commits to the current upstream.


### PR DESCRIPTION
Fixes git-auto-commit-mode for files with spaces in the filename.