### PR TITLE
Add support for commit debouncing

### DIFF
--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -180,7 +180,6 @@ should already have been set up."
   "Commit the current file.
 
 When `gac-automatically-push-p' is non-nil also push."
-
   (if gac-debounce-interval
       (gac--debounced-save)
     (gac--after-save (current-buffer))))

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -1,4 +1,4 @@
-;;; git-auto-commit-mode.el --- Emacs Minor mode to automatically commit and push
+;;; git-auto-commit-mode.el --- Emacs Minor mode to automatically commit and push  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012, 2013, 2014, 2015 Tom Willemse <tom@ryuslash.org>
 
@@ -36,8 +36,6 @@
 
 ;;; Code:
 
-(require 'cl)
-
 (defgroup git-auto-commit-mode nil
   "Customization options for `git-auto-commit-mode'."
   :group 'external)
@@ -68,10 +66,13 @@ If non-nil a git push will be executed after each commit."
 (defcustom gac-debounce-interval nil
   "Debounce automatic commits to avoid hammering Git.
 
-If non-nil a commit will be scheduled to occur that many seconds in the future. Note that this uses Emacs timer functionality, and is subject to its limitations."
-  :tag "Debounce to only make one commit this many seconds."
+If non-nil a commit will be scheduled to occur that many seconds
+in the future. Note that this uses Emacs timer functionality, and
+is subject to its limitations."
+  :tag "Debounce interval"
   :group 'git-auto-commit-mode
-  :type 'fixnum)
+  :type '(choice (number :tag "Interval in seconds")
+                 (const :tag "Off" nil)))
 (make-variable-buffer-local 'gac-debounce-interval)
 
 (defun gac-relative-file-name (filename)
@@ -125,55 +126,53 @@ Default to FILENAME."
         relative-filename
       (read-string "Summary: " nil nil relative-filename))))
 
-(defun gac-commit (actual-buffer)
+(defun gac-commit (buffer)
   "Commit the current buffer's file to git."
-  (with-current-buffer (or actual-buffer (current-buffer))
-    (let* ((buffer-file (buffer-file-name))
-           (filename (convert-standard-filename
-                      (file-name-nondirectory buffer-file)))
-           (commit-msg (gac--commit-msg buffer-file))
-           (default-directory (file-name-directory buffer-file)))
-      (shell-command
-       (concat "git add " (shell-quote-argument filename)
-               " && git commit -m " (shell-quote-argument commit-msg))))))
+  (let* ((buffer-file (buffer-file-name buffer))
+         (filename (convert-standard-filename
+                    (file-name-nondirectory buffer-file)))
+         (commit-msg (gac--commit-msg buffer-file))
+         (default-directory (file-name-directory buffer-file)))
+    (shell-command
+     (concat "git add " (shell-quote-argument filename)
+             gac-shell-and
+             "git commit -m " (shell-quote-argument commit-msg)))))
 
-(defun gac-push (actual-buffer)
+(defun gac-push (buffer)
   "Push commits to the current upstream.
 
 This doesn't check or ask for a remote, so the correct remote
 should already have been set up."
-  (with-current-buffer (or actual-buffer (current-buffer))
+  (with-current-buffer buffer
     (let ((proc (start-process "git" "*git-auto-push*" "git" "push")))
       (set-process-sentinel proc 'gac-process-sentinel)
       (set-process-filter proc 'gac-process-filter))))
 
-(setq gac--debounce-timers (make-hash-table :test #'equal))
+(defvar gac--debounce-timers (make-hash-table :test #'equal))
 
 (defun gac--debounced-save ()
-  (lexical-let* ((actual-buffer (current-buffer))
-                 (current-buffer-debounce-timer (gethash actual-buffer gac--debounce-timers)))
+  (let* ((actual-buffer (current-buffer))
+         (current-buffer-debounce-timer (gethash actual-buffer gac--debounce-timers)))
     (unless current-buffer-debounce-timer
       (puthash actual-buffer
                (run-at-time gac-debounce-interval nil
-                            (lambda (actual-buffer)
-                              (gac--after-save actual-buffer))
+                            #'gac--after-save
                             actual-buffer)
                gac--debounce-timers))))
 
-(defun gac--after-save (&optional actual-buffer)
-  (let ((actual-buffer (or actual-buffer (current-buffer))))
-    (unwind-protect
-        (when (buffer-live-p actual-buffer)
-          (gac-commit actual-buffer)
-          (when gac-automatically-push-p
-            (gac-push actual-buffer)))
-      (remhash actual-buffer gac--debounce-timers))))
+(defun gac--after-save (buffer)
+  (unwind-protect
+      (when (buffer-live-p buffer)
+        (gac-commit buffer)
+        (when gac-automatically-push-p
+          (gac-push buffer)))
+    (remhash buffer gac--debounce-timers)))
 
 (defun gac-kill-buffer-hook ()
   (when (and gac-debounce-interval
              gac--debounce-timers
              (gethash (current-buffer) gac--debounce-timers))
-    (gac--after-save)))
+    (gac--after-save (current-buffer))))
 
 (add-hook 'kill-buffer-hook #'gac-kill-buffer-hook)
 
@@ -184,7 +183,7 @@ When `gac-automatically-push-p' is non-nil also push."
 
   (if gac-debounce-interval
       (gac--debounced-save)
-    (gac--after-save)))
+    (gac--after-save (current-buffer))))
 
 ;;;###autoload
 (define-minor-mode git-auto-commit-mode


### PR DESCRIPTION
This patch prevents frequent saves from making an excessively large number of
commits. With gac-debounce-interval (a buffer-specific variable) set to a number
representing seconds, buffers with git-auto-commit-mode active will only make
Git commits at the end of the given interval after a save. So with
gac-debounce-interval set to 300, a buffer will commit changes accumulated over
5 minutes, rather than at every save. It will also commit if the buffer is
killed.

This mode of operation can be made default with, e.g.:

    (setq-default gac-debounce-interval 300)