### PR TITLE
Commit auto-commits to separate branch...

### DIFF
--- a/README.org
+++ b/README.org
@@ -94,8 +94,29 @@
     made, but not the file from being saved.
 
   - =gac-shell-and= ::
-    A string that can be used to change how the shell combines commands. The
+    A string that can be used to change how the shell combines commands like
+    ~CMD1 AND CMD2~, where CMD2 should only be run if CMD1 succeeds. The
     default " && " is good for bash-like shells, but " ; and " would be used for
+    fish, for example.
+
+  - =gac-shell-or= ::
+    A string that can be used to change how the shell combines commands like
+    ~CMD1 OR CMD2~, where CMD2 should only be run if CMD1 doesn't succeed. The
+    default " || " is good for bash-like shells, but " ; or " would be used for
+    fish, for example.
+
+  - =gac-shell-begin= ::
+    A string that can be used to change how the shell starts chains of commands
+    like ~BEGIN CMD1; CMD2 END~, where CMD1 and CMD2 are both run and where
+    the exit status of the chain is the exit status of CMD2. The default
+    " { " is good for bash-like shells, but " begin " would be used for
+    fish, for example.
+
+  - =gac-shell-end= ::
+    A string that can be used to change how the shell ends chains of commands
+    like ~BEGIN CMD1; CMD2 END~, where CMD1 and CMD2 are both run and where
+    the exit status of the chain is the exit status of CMD2. The default
+    " ; } " is good for bash-like shells, but " ; end " would be used for
     fish, for example.
 
   - =gac-debounce-interval= ::

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -265,6 +265,10 @@ Standard error is inserted into a temp buffer if it's generated."
     (gac--shell-command-throw
      (concat "git add " gac-add-additional-flag " " (shell-quote-argument filename)
              gac-shell-and
+             ;; Check if working directory is clean before attempting to
+             ;; commit; if it is, `git commit` will exit with exit code 1.
+             "{ git diff --exit-code && git diff --cached --exit-code; }"
+             "||"
              "git commit -m " (shell-quote-argument commit-msg)))))
 
 (defun gac-merge (buffer)

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -96,8 +96,35 @@ changes made since the current file was loaded."
   :type 'boolean)
 
 (defcustom gac-shell-and " && "
-  "How to join commands together in the shell. For fish shell,
-  you want to customise this to: \" ; and \" instead of the default."
+  "The syntax to use for CMD1 AND CMD2, where CMD2 should only be run if CMD1
+  is successful. For fish shell, you want to customise this to: \" ; and \"
+  instead of the default."
+  :tag "Join shell commands"
+  :group 'git-auto-commit-mode
+  :type 'string)
+
+(defcustom gac-shell-or " || "
+  "The syntax to use for CMD1 OR CMD2, where CMD2 should only be run if CMD1
+  is not successful. For fish shell, you want to customise this to: \" ; and \"
+  instead of the default."
+  :tag "Join shell commands"
+  :group 'git-auto-commit-mode
+  :type 'string)
+
+(defcustom gac-shell-begin " { "
+  "The syntax to use for BEGIN in BEGIN CMD1; CMD2; END, where CMD2 should be
+  run after CMD1 and the whole expression return the exit code of CMD2.
+  For fish shell, you want to customise this to: \" begin \"
+  instead of the default."
+  :tag "Join shell commands"
+  :group 'git-auto-commit-mode
+  :type 'string)
+
+(defcustom gac-shell-end " ; } "
+  "The syntax to use for END in BEGIN CMD1; CMD2 END, where CMD2 should be
+  run after CMD1 and the whole expression return the exit code of CMD2.
+  For fish shell, you want to customise this to: \" ; end \"
+  instead of the default."
   :tag "Join shell commands"
   :group 'git-auto-commit-mode
   :type 'string)
@@ -274,8 +301,12 @@ Standard error is inserted into a temp buffer if it's generated."
              gac-shell-and
              ;; Check if working directory is clean before attempting to
              ;; commit; if it is, `git commit` will exit with exit code 1.
-             "{ git diff --exit-code && git diff --cached --exit-code; }"
-             "||"
+             gac-shell-begin
+             "git diff --exit-code"
+             gac-shell-and
+             "git diff --cached --exit-code"
+             gac-shell-end
+             gac-shell-or
              "git commit -m " (shell-quote-argument commit-msg)))))
 
 (defun gac-merge (buffer)

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -209,6 +209,12 @@ Default to FILENAME."
     (replace-regexp-in-string "\n\\'" ""
         (gac--shell-command-to-string-throw "git symbolic-ref --short HEAD"))))
 
+(defun gac--buffer-file-tracked ()
+  "Is the current buffer's file tracked in Git?"
+  (eq 0
+      (call-process "git" nil nil nil "ls-files" "--error-unmatch"
+                    (buffer-file-name))))
+
 (defun gac--shell-command-throw (command)
   "Run shell command, but raise a lisp error if the command returns nonzero.
 
@@ -345,7 +351,8 @@ should already have been set up."
                  (string=
 		   "true\n"
                    (gac--shell-command-to-string-throw
-                    "git rev-parse --is-inside-work-tree")))
+                    "git rev-parse --is-inside-work-tree"))
+	         (gac--buffer-file-tracked))
         (gac-commit buffer)
 	(gac-merge buffer)
         (with-current-buffer buffer
@@ -369,7 +376,8 @@ should already have been set up."
 
 (defun gac-before-save-func ()
   "Create and check out a merge branch."
-  (gac-checkout-merge-branch))
+  (when (gac--buffer-file-tracked)
+    (gac-checkout-merge-branch)))
 
 (defun gac-after-save-func ()
   "Commit the current file.

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -217,8 +217,8 @@ Output and error printed to a temporary buffer."
          (rv (call-process-shell-command command nil buf)))
     (unless (eql 0 rv)
       (error (concat "gac--shell-command-throw: "
-                     "Exit code %d from command: %s"
-                     rv command)))))
+                     "Exit code %d from command: %s")
+             rv command))))
 
 (defun gac--shell-command-to-string-throw (command)
   "Run shell command and return standard output as string.

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -377,10 +377,11 @@ When `gac-automatically-push-p' is non-nil also push."
 mode turned on and optionally push them too."
   :lighter " ga"
   (cond (git-auto-commit-mode
-         (gac--load-current-commit)
-         (add-hook 'find-file-hook 'gac-find-file-func t t)
-         (add-hook 'before-save-hook 'gac-before-save-func t t)
-         (add-hook 'after-save-hook 'gac-after-save-func t t))
+         (unless (null (buffer-file-name))
+           (gac--load-current-commit)
+           (add-hook 'find-file-hook 'gac-find-file-func t t)
+           (add-hook 'before-save-hook 'gac-before-save-func t t)
+           (add-hook 'after-save-hook 'gac-after-save-func t t)))
         (t
          (remove-hook 'find-file-hook 'gac-find-file-func t)
          (remove-hook 'before-save-hook 'gac-before-save-func t)

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -341,7 +341,11 @@ should already have been set up."
       (when (and (buffer-live-p buffer)
                  (or (and gac-automatically-add-new-files-p
                           (not (gac--buffer-is-tracked buffer)))
-                     (gac--buffer-has-changes buffer)))
+                     (gac--buffer-has-changes buffer))
+                 (string=
+		   "true\n"
+                   (gac--shell-command-to-string-throw
+                    "git rev-parse --is-inside-work-tree")))
         (gac-commit buffer)
 	(gac-merge buffer)
         (with-current-buffer buffer


### PR DESCRIPTION
...before merging the auto-commit back into the main branch.

This protects against the following scenario:

1. You've loaded a file at commit A.
2. While your file is unsaved, the repo underneath is updated to some commit B
   that is a descendant of A.
3. You save your file. Emacs prompts you that the file underneath has changed.
   You decide to overwrite, but you've lost the differences between A and B.

Now, we first switch to a temp branch and save the file as a commit on top of
commit A, and then switch back to the branch with commit B and merge the temp
branch (with our new change) back in.

Note to maintainer: I've also sent you an email with this pull request using `git request-pull`.