### PR TITLE
Add configuration for git commit flags and silent commits

### DIFF
--- a/README.org
+++ b/README.org
@@ -109,3 +109,8 @@
   - =gac-commit-additional-flag= ::
     A string that can be used to add additional command line flags to the ~git
     commit~ command.
+
+  - =gac-silent-message-p= ::
+    A boolean value indicating whether to display the commit summary message,
+    which is usually displayed in the minibuffer. The default is ~nil~, meaning
+    that the summary would be displayed on every commit.

--- a/README.org
+++ b/README.org
@@ -101,3 +101,11 @@
   - =gac-debounce-interval= ::
     A number specifying a buffer between automatic commits in seconds. Wait with
     making an actual commit until this number of seconds elapses.
+
+  - =gac-add-additional-flag= ::
+    A string that can be used to add additional command line flags to the ~git
+    add~ command.
+
+  - =gac-commit-additional-flag= ::
+    A string that can be used to add additional command line flags to the ~git
+    commit~ command.

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -75,6 +75,12 @@ If non-nil a git push will be executed after each commit."
        :group 'git-auto-commit-mode
        :type 'string)
 
+(defcustom gac-commit-additional-flag ""
+    "Flag to add to the git commit command."
+    :tag "git commit flag"
+    :group 'git-auto-commit-mode
+    :type 'string)
+
 
 (defcustom gac-debounce-interval nil
   "Debounce automatic commits to avoid hammering Git.
@@ -169,7 +175,8 @@ Default to FILENAME."
     (shell-command
      (concat "git add " gac-add-additional-flag " " (shell-quote-argument filename)
              gac-shell-and
-             "git commit -m " (shell-quote-argument commit-msg)))))
+             "git commit -m " (shell-quote-argument commit-msg)
+             " " gac-commit-additional-flag))))
 
 (defun gac-push (buffer)
   "Push commits to the current upstream.

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -81,6 +81,12 @@ If non-nil a git push will be executed after each commit."
     :group 'git-auto-commit-mode
     :type 'string)
 
+(defcustom gac-silent-message-p nil
+    "Should git output be output to the message area?"
+    :tag "Quiet message output"
+    :group 'git-auto-commit-mode
+    :type 'boolean)
+
 
 (defcustom gac-debounce-interval nil
   "Debounce automatic commits to avoid hammering Git.
@@ -172,7 +178,9 @@ Default to FILENAME."
                     (file-name-nondirectory buffer-file)))
          (commit-msg (gac--commit-msg buffer-file))
          (default-directory (file-name-directory buffer-file)))
-    (shell-command
+    (funcall (if gac-silent-message-p
+                 #'call-process-shell-command
+                 #'shell-command)
      (concat "git add " gac-add-additional-flag " " (shell-quote-argument filename)
              gac-shell-and
              "git commit -m " (shell-quote-argument commit-msg)


### PR DESCRIPTION
* Added documentation in the README for `gac-add-additional-flag`
* Added `gac-commit-additional-flag` to add flags to `git commit` as an analog for `gac-add-additional-flag`, along with documentation
* Added `gac-silent-message-p` to have a completely silent commit message, fixing issue #28. I'm not exactly sure what the semantics are of `call-process-shell-command` vs `shell-command`, but seems to be working fairly well so far.