### PR TITLE
Configure Git in tests

### DIFF
--- a/tests/git-auto-commit-mode-tests.el
+++ b/tests/git-auto-commit-mode-tests.el
@@ -27,6 +27,11 @@
 (require 'buttercup)
 (require 'git-auto-commit-mode)
 
+(defun gas-test-setup-git ()
+  (shell-command "git init")
+  (shell-command "git config user.email user@example.com")
+  (shell-command "git config user.name \"User Example\""))
+
 (describe "New files"
   (describe "When ‘gac-automatically-add-new-files’ is t"
     (it "Should be added to git"
@@ -36,7 +41,7 @@
              (default-directory temp-dir))
         (unwind-protect
             (progn
-              (shell-command "git init")
+              (gas-test-setup-git)
               (let ((buffer (find-file-noselect temp-file)))
                 (with-current-buffer buffer
                   (git-auto-commit-mode)
@@ -54,7 +59,7 @@
              (default-directory temp-dir))
         (unwind-protect
             (progn
-              (shell-command "git init")
+              (gas-test-setup-git)
               (let ((buffer (find-file-noselect temp-file)))
                 (with-current-buffer buffer
                   (git-auto-commit-mode)
@@ -71,7 +76,7 @@
            (default-directory temp-dir))
       (unwind-protect
           (progn
-            (shell-command "git init")
+            (gas-test-setup-git)
             (let ((buffer (find-file-noselect temp-file)))
               (with-current-buffer buffer
                 (git-auto-commit-mode)
@@ -88,7 +93,7 @@
       (mkdir (expand-file-name "test" temp-dir))
       (unwind-protect
           (progn
-            (shell-command "git init")
+            (gas-test-setup-git)
             (let ((buffer (find-file-noselect temp-file)))
               (with-current-buffer buffer
                 (git-auto-commit-mode)
@@ -104,7 +109,7 @@
            (default-directory temp-dir))
       (unwind-protect
           (progn
-            (shell-command "git init")
+            (gas-test-setup-git)
             (let ((buffer (find-file-noselect temp-file)))
               (with-current-buffer buffer
                 (git-auto-commit-mode)
@@ -121,7 +126,7 @@
       (mkdir (expand-file-name "[test]-test" temp-dir))
       (unwind-protect
           (progn
-            (shell-command "git init")
+            (gas-test-setup-git)
             (let ((buffer (find-file-noselect temp-file)))
               (with-current-buffer buffer
                 (git-auto-commit-mode)
@@ -137,7 +142,7 @@
            (default-directory temp-dir))
       (unwind-protect
           (progn
-            (shell-command "git init")
+            (gas-test-setup-git)
             (let ((buffer (find-file-noselect temp-file)))
               (with-current-buffer buffer
                 (git-auto-commit-mode)
@@ -153,7 +158,7 @@
            (default-directory temp-dir))
       (unwind-protect
           (progn
-            (shell-command "git init")
+            (gas-test-setup-git)
             (let ((buffer (find-file-noselect temp-file)))
               (with-current-buffer buffer
                 (git-auto-commit-mode)


### PR DESCRIPTION
Hi!

I try to run test suite in Guix package manager which builds and check packages it in a chroot environment.  This commit fixes test suite for systems without global Git config.
```
[pid  3137] sendto(3, "\2\0\0\0\r\0\0\0\6\0\0\0hosts\0", 18, MSG_NOSIGNAL, NULL, 0) = 18
[pid  3137] poll([{fd=3, events=POLLIN|POLLERR|POLLHUP}], 1, 5000) = 1 ([{fd=3, revents=POLLIN|POLLHUP}])
[pid  3137] recvmsg(3, {msg_name=NULL, msg_namelen=0, msg_iov=[{iov_base="hosts\0", iov_len=6}, {iov_base="\310O\3\0\0\0\0\0", iov_len=8}], msg_iovlen=2, msg_control=[{cmsg_len=20, cmsg_le>
[pid  3137] mmap(NULL, 217032, PROT_READ, MAP_SHARED, 4, 0) = 0x7f2a043b5000
[pid  3137] close(4)                    = 0
[pid  3137] close(3)                    = 0
[pid  3137] write(2, "\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email \"you@example.com\"\n  git config --global user.name \"Your Name\"\n\nto set your account>
[pid  3014] <... read resumed>"\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email \"you@example.com\"\n  git config --global user.name \"Your Name\"\n\nto set you>
[pid  3137] write(2, "fatal: unable to auto-detect email address (got 'oleg@guixsd.(none)')\n", 70 <unfinished ...>
[pid  3014] read(5,  <unfinished ...>
[pid  3137] <... write resumed>)        = 70
[pid  3014] <... read resumed>"fatal: unable to auto-detect email address (got 'oleg@guixsd.(none)')\n", 16149) = 70
```