### PR TITLE
fix relative pathnames

### DIFF
--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -122,7 +122,7 @@ It can be:
   (let* ((git-dir
           (string-trim-right
            (shell-command-to-string "git rev-parse --show-toplevel"))))
-    (file-relative-name filename git-dir)))
+    (file-relative-name (file-truename filename) (file-truename git-dir))))
 
 (defun gac-password (proc string)
   "Ask the user for a password when necessary.


### PR DESCRIPTION
Sometimes, the relative pathname computation gets confused, resulting in
a commit message that looks like this:

    ../../../tank/foo/bar.txt

     bar.txt | 10 +++++-----
      1 file changed, 5 insertions(+), 5 deletions(-)

This commit uses the emacs function file-truename to convert both paths
to absolute pathnames first, then computing the relative path between
them, which should yield the correct relative pathname in all situations.