### PR TITLE
Add automatic pull support

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 
 * NAME
 
-  git-auto-commit-mode - Emacs minor mode to automatically commit (and
+  git-auto-commit-mode - Emacs minor mode to automatically commit (and pull and
   push) a git repository.
 
   [[http://melpa.org/#/git-auto-commit-mode][file:http://melpa.org/packages/git-auto-commit-mode-badge.svg]]
@@ -26,6 +26,8 @@
   When enabled, git-auto-commit-mode uses the =after-save-hook= to
   commit changes to git each time. If =gac-automatically-push-p= is
   non-nil it also tries to push the ~HEAD~ to the current upstream.
+  If =gac-automatically-pull-p= is
+  non-nil it also tries to pull the ~HEAD~ to the current upstream.
   Making sure that upstream is properly set is the responsibility of
   the user.
 
@@ -81,6 +83,11 @@
     A boolean value indicating whether or not git-auto-commit-mode should try to
     push the git repository's ~HEAD~ to its default upstream. Setting up the
     upstream is the user's responsibility.
+
+  - =gac-automatically-pull-p= ::
+    A boolean value indicating whether or not git-auto-commit-mode should try to
+    pull the git repository's ~HEAD~ from its default upstream. Setting up the
+    upstream is the user's responsibility.    
 
   - =gac-automatically-add-new-files-p= ::
     A boolean value indicating whether or not git-auto-commit-mode should add

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -29,6 +29,9 @@
 ;; When `gac-automatically-push-p' is non-nil, it also tries to push
 ;; to the current upstream.
 
+;; When `gac-automatically-pull-p' is non-nil, it also tries to pull
+;; from the current upstream.
+
 ;; When `gac-debounce-interval' is non-nil and set to a number
 ;; representing seconds, it will only perform Git actions at that
 ;; interval. That way, repeatedly saving a file will not hammer the
@@ -51,6 +54,16 @@ If non-nil a git push will be executed after each commit."
   :type 'boolean
   :risky t)
 (make-variable-buffer-local 'gac-automatically-push-p)
+
+(defcustom gac-automatically-pull-p nil
+  "Automatically pull before each commit.
+
+If non-nil a git pull will be executed before each commit."
+  :tag "Automatically pull"
+  :group 'git-auto-commit-mode
+  :type 'boolean
+  :risky t)
+(make-variable-buffer-local 'gac-automatically-pull-p)
 
 (defcustom gac-automatically-add-new-files-p t
   "Should new (untracked) files automatically be committed to the repo?"
@@ -197,6 +210,21 @@ should already have been set up."
       (set-process-sentinel proc 'gac-process-sentinel)
       (set-process-filter proc 'gac-process-filter))))
 
+(defun gac-pull (buffer)
+  "Pull commits from the current upstream.
+
+This doesn't check or ask for a remote, so the correct remote
+should already have been set up."
+  ;; gac-pull is currently only called from gac--after-save, where it is wrapped
+  ;; in with-current-buffer, which should already take care of
+  ;; default-directory. The explicit binding here is defensive, in case gac-pull
+  ;; starts being used elsewhere.
+  (let ((default-directory (file-name-directory (buffer-file-name buffer))))
+    (let ((proc (start-process "git" "*git-auto-pull*" "git" "pull")))
+      (set-process-sentinel proc 'gac-process-sentinel)
+      (set-process-filter proc 'gac-process-filter))))
+
+
 (defvar gac--debounce-timers (make-hash-table :test #'equal))
 
 (defun gac--debounced-save ()
@@ -233,6 +261,11 @@ should already have been set up."
                  (or (and gac-automatically-add-new-files-p
                           (not (gac--buffer-is-tracked buffer)))
                      (gac--buffer-has-changes buffer)))
+        (with-current-buffer buffer
+          ;; with-current-buffer required here because gac-automatically-pull-p
+          ;; is buffer-local
+          (when gac-automatically-pull-p
+            (gac-pull buffer)))
         (gac-commit buffer)
         (with-current-buffer buffer
           ;; with-current-buffer required here because gac-automatically-push-p
@@ -252,6 +285,8 @@ should already have been set up."
 (defun gac-after-save-func ()
   "Commit the current file.
 
+When `gac-automatically-pull-p' is non-nil also pull.
+
 When `gac-automatically-push-p' is non-nil also push."
   (if gac-debounce-interval
       (gac--debounced-save)
@@ -260,7 +295,7 @@ When `gac-automatically-push-p' is non-nil also push."
 ;;;###autoload
 (define-minor-mode git-auto-commit-mode
   "Automatically commit any changes made when saving with this
-mode turned on and optionally push them too."
+mode turned on, optionally pull and push them too."
   :lighter " ga"
   (if git-auto-commit-mode
       (add-hook 'after-save-hook 'gac-after-save-func t t)

--- a/git-auto-commit-mode.el
+++ b/git-auto-commit-mode.el
@@ -274,10 +274,7 @@ should already have been set up."
 
 (defun gac--before-save (buffer)
   (unwind-protect
-      (when (and (buffer-live-p buffer)
-                 (or (and gac-automatically-add-new-files-p
-                          (not (gac--buffer-is-tracked buffer)))
-                     (gac--buffer-has-changes buffer)))
+      (when (buffer-live-p buffer)
         (with-current-buffer buffer
           ;; with-current-buffer required here because gac-automatically-pull-p
           ;; is buffer-local


### PR DESCRIPTION
I have been happily using git-auto-commit-mode, but when the git repo is being worked on separately from different locations then I get merge conflicts when trying to auto push. This is a bit of a nuisance when doing something like working in a directory of org files and the conflicts are automatically mergable but it is easy to not notice that there was a merge conflict (plus it still requires manual resolution). 

This PR introduces automatic pull support which runs in a before-save-hook. It works the same way as auto push, but simply pulls before the buffer is saved. It is also labeled as risky.